### PR TITLE
Fix CVE-2020-8130

### DIFF
--- a/niboshi_json_formatter.gemspec
+++ b/niboshi_json_formatter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 1.17.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3"
 end


### PR DESCRIPTION
## Fearures

- Fix [CVE-2020-8130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8130) 
- Update Bundler gem to the latest version that supports the Ruby version <= 2.3.x  